### PR TITLE
Add Remio to AI document office tools

### DIFF
--- a/site-info.json
+++ b/site-info.json
@@ -5935,6 +5935,25 @@
         "AI 绘图"
       ]
     },
+    "https://remio.ai/": {
+      "title": "Remio",
+      "intro": "本地 AI 个人知识库",
+      "desc": "Remio 是一款本地优先的 AI 个人知识库桌面应用，可解析文件、网页、录音、邮件、聊天记录、图片和笔记，并在本地建立索引和向量，帮助用户和 Agent 快速检索个人上下文，减少反复扫描目录或整篇加载文档带来的 token 成本。",
+      "lang": "zh",
+      "tags": [
+        "个人知识库",
+        "文档办公",
+        "本地索引",
+        "AI记忆",
+        "Agent上下文"
+      ],
+      "type": [
+        "AI 文档办公"
+      ],
+      "needLogin": 1,
+      "needPay": 1,
+      "needVerify": 1
+    },
     "https://replicate.com/lucataco/whisperspeech-small": {
       "title": "Whisper Speech",
       "intro": "开源文本转语音系统",


### PR DESCRIPTION
## Summary

Add Remio to site-info.json under AI 文档办公.

Remio is a local-first AI personal knowledge base desktop app. It parses files, webpages, recordings, emails, chat records, images, and notes into local indexes and vectors, helping users and agents retrieve focused personal context and reduce repeated directory scans or whole-document prompt loading.

## Notes

The entry follows the repository's existing self-recommendation data format and marks the site as requiring login/payment/verification where appropriate.